### PR TITLE
keep only python3-wb-test-suite-deps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-metapackages (1.13.0) stable; urgency=medium
+
+  * provide python3-wb-test-suite-deps exclusively
+  * remove old python2 test-suite deps
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Fri, 14 Oct 2022 18:52:47 +0600
+
 wb-metapackages (1.12.0) stable; urgency=medium
 
   * add python3-wb-test-suite-deps metapackage

--- a/debian/control
+++ b/debian/control
@@ -41,17 +41,11 @@ Depends: ${misc:Depends}, wb-essential,
          wb-mcu-fw-flasher, wb-mcu-fw-updater,
          wb-mqtt-confed, wb-mqtt-opcua, wb-mqtt-logs, wb-diag-collect, wb-mqtt-metrics
 
-Package: wb-test-suite-deps
-Architecture: all
-Description: Wiren Board test-suite dependencies
- This metapackage pulls in all the packages required for Wiren Board
- post-production tests
-Depends: ${misc:Depends}, device-tree-compiler, python-mysqldb, python-termcolor, python-serial,
-    python-can, python-smbus, python-six, wb-hwconf-manager (>= 1.25), wb-utils (>= 1.65),
-    python-wb-common (>= 1.3.3), wb-mqtt-adc (>= 2.0.7)
-
 Package: python3-wb-test-suite-deps
 Architecture: all
+Provides: wb-test-suite-deps
+Breaks: wb-test-suite-deps (<= 1.12.0)
+Replaces: wb-test-suite-deps (<= 1.12.0)
 Description: Wiren Board test-suite dependencies (python3 packages)
  This metapackage pulls in all the packages required for Wiren Board
  post-production tests (python3)


### PR DESCRIPTION
В bullseye не останется старого пакета wb-test-suite-deps, останется только оный для python3 (который, впрочем, всё ещё можно установить через `apt install wb-test-suite-deps`)