### PR TITLE
remove wb-common from test-suite deps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-metapackages (1.14.0) stable; urgency=medium
+
+  * remove wb-common from test-suite deps (moved to test-suite)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 02 Nov 2022 12:04:44 +0600
+
 wb-metapackages (1.13.0) stable; urgency=medium
 
   * provide python3-wb-test-suite-deps exclusively

--- a/debian/control
+++ b/debian/control
@@ -51,7 +51,7 @@ Description: Wiren Board test-suite dependencies (python3 packages)
  post-production tests (python3)
 Depends: ${misc:Depends}, device-tree-compiler, python3-mysqldb, python3-termcolor, python3-serial,
     python3-can, python3-smbus, python3-six, wb-hwconf-manager (>= 1.25), wb-utils (>= 1.65),
-    python3-wb-common (>= 1.5.0), wb-mqtt-adc (>= 2.0.7)
+    wb-mqtt-adc (>= 2.0.7)
 
 Package: wb-test-suite-dummy
 Architecture: all


### PR DESCRIPTION
wb-common переехал в test-suite, так было проще организационно. Потому зависимость больше не нужна