### PR TITLE
wb-suite: use python3-wb-test-suite-deps instead of old python2's

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-metapackages (1.15.0) stable; urgency=medium
+
+  * wb-suite: use python3-wb-test-suite-deps instead of old python2's
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 07 Nov 2022 13:09:16 +0600
+
 wb-metapackages (1.14.0) stable; urgency=medium
 
   * remove wb-common from test-suite deps (moved to test-suite)

--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,8 @@ Package: wb-suite
 Architecture: all
 Description: Wirenboard vendor software set
  This metapackage pulls in all the packages from Wirenboard vendor
-Recommends: wb-test-suite-deps | python3-wb-test-suite-deps, wb-update-notifier
+Recommends: python3-wb-test-suite-deps, wb-update-notifier
+Breaks: wb-test-suite-deps (<= 1.12.0)
 Depends: ${misc:Depends}, wb-essential,
 # configuration
          wb-knxd-config,


### PR DESCRIPTION
Добавил также конфликт со старыми wb-test-suite-deps, чтобы наверняка обновилось (может понадобиться команда `apt-get dist-upgrade`, потому что потянет за собой удаление пакетов