### PR TITLE
wb-suite: add modbus-utils-rpc to recommends

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-metapackages (1.17.2) stable; urgency=medium
+
+  * wb-suite: add modbus-utils-rpc to recommends
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com> Thu, 04 May 2023 16:32:00 +0400
+
 wb-metapackages (1.17.1) stable; urgency=medium
 
   * wb-suite: add gpiod ro recommends

--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,7 @@ Package: wb-suite
 Architecture: all
 Description: Wirenboard vendor software set
  This metapackage pulls in all the packages from Wirenboard vendor
-Recommends: python3-wb-test-suite-deps, wb-update-notifier, mc, gpiod
+Recommends: python3-wb-test-suite-deps, wb-update-notifier, mc, gpiod, modbus-utils-rpc
 Breaks: wb-test-suite-deps (<= 1.12.0)
 Depends: ${misc:Depends}, wb-essential,
 # configuration


### PR DESCRIPTION
Depends on https://github.com/wirenboard/modbus-utils-rpc/pull/15