### PR TITLE
Fix deb/changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,14 +1,20 @@
+wb-metapackages (1.17.3) stable; urgency=medium
+
+  * Fix deb/changelog
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 25 Jul 2023 20:02:00 +0400
+
 wb-metapackages (1.17.2) stable; urgency=medium
 
   * wb-suite: add modbus-utils-rpc to recommends
 
- -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com> Thu, 04 May 2023 16:32:00 +0400
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 04 May 2023 16:32:00 +0400
 
 wb-metapackages (1.17.1) stable; urgency=medium
 
   * wb-suite: add gpiod ro recommends
 
- --Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Tue, 02 May 2023 15:26:07 +0300
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Tue, 02 May 2023 15:26:07 +0300
 
 wb-metapackages (1.17.0) stable; urgency=medium
 


### PR DESCRIPTION
Changelog генератор ловит артефакты:

<img width="1423" alt="Näyttökuva 2023-7-25 kello 21 19 27" src="https://github.com/wirenboard/wb-metapackages/assets/688044/7c9c1d66-bcbe-4cfc-9cb1-48ad10b9ae73">

И lintian ругается:
```sh
W: python3-wb-test-suite-deps: syntax-error-in-debian-changelog line 11 "badly formatted trailer line"
W: python3-wb-test-suite-deps: syntax-error-in-debian-changelog line 13 "found start of entry where expected more change data or trailer"
W: python3-wb-test-suite-deps: syntax-error-in-debian-changelog line 5 "badly formatted trailer line"
W: wb-essential: syntax-error-in-debian-changelog line 11 "badly formatted trailer line"
W: wb-essential: syntax-error-in-debian-changelog line 13 "found start of entry where expected more change data or trailer"
W: wb-essential: syntax-error-in-debian-changelog line 5 "badly formatted trailer line"
W: wb-suite: syntax-error-in-debian-changelog line 11 "badly formatted trailer line"
W: wb-suite: syntax-error-in-debian-changelog line 13 "found start of entry where expected more change data or trailer"
W: wb-suite: syntax-error-in-debian-changelog line 5 "badly formatted trailer line"
W: wb-test-suite-dummy: syntax-error-in-debian-changelog line 11 "badly formatted trailer line"
W: wb-test-suite-dummy: syntax-error-in-debian-changelog line 13 "found start of entry where expected more change data or trailer"
W: wb-test-suite-dummy: syntax-error-in-debian-changelog line 5 "badly formatted trailer line"
```