### PR TITLE
wb-essetial: add wb-firmware-realtek

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-metapackages (1.18.0) stable; urgency=medium
+
+  * wb-essetial: add wb-firmware-realtek
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 10 Oct 2023 16:27:03 +0500
+
 wb-metapackages (1.17.4) stable; urgency=medium
 
   * task-wb-base-system and task-wb-common-pkgs added

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,9 @@ Depends: ${misc:Depends},
 # kernel
          linux-image-wb7 | linux-image-wb6 | linux-image-wb2,
 # u-boot image and tools
-         u-boot-wb7 | u-boot-wb6, u-boot-tools-wb
+         u-boot-wb7 | u-boot-wb6, u-boot-tools-wb,
+# firmwares for drivers
+         wb-firmware-realtek
 Recommends: exfat-fuse
 
 Package: wb-suite


### PR DESCRIPTION
Это пакет с прошивкой для нового wifi-bluetooth чипа. Без этой прошивки не будет работать bluetooth. 