### PR TITLE
Remove cmux,hubpower,python-wb-io deps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-metapackages (1.18.4) stable; urgency=medium
+
+  * task-wb-common-pkgs: remove cmux,hubpower,python-wb-io
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 20 Mar 2024 13:40:00 +0400
+
 wb-metapackages (1.18.3) stable; urgency=medium
 
   * remove wb-mqtt-snmp, wb-mqtt-smartweb from wb-suite

--- a/debian/control
+++ b/debian/control
@@ -71,7 +71,7 @@ Package: task-wb-common-pkgs
 Architecture: all
 Description: Wiren Board common packages
  This metapackage brings wb-common packages for all new WB in wirenboard/boards/ section.(smth for rootfs gen). 
-Depends: ${misc:Depends}, cmux, hubpower, python-wb-io, modbus-utils, busybox, libmosquittopp1, libmosquitto1, mosquitto, mosquitto-clients, openssl, ca-certificates, avahi-daemon, pps-tools, device-tree-compiler, libateccssl1.1, knxd, knxd-tools, wb-suite, netplug, hostapd, bluez, can-utils, u-boot-tools-wb, cron, bluez-hcidump 
+Depends: ${misc:Depends}, modbus-utils, busybox, libmosquittopp1, libmosquitto1, mosquitto, mosquitto-clients, openssl, ca-certificates, avahi-daemon, pps-tools, device-tree-compiler, libateccssl1.1, knxd, knxd-tools, wb-suite, netplug, hostapd, bluez, can-utils, u-boot-tools-wb, cron, bluez-hcidump
 
 Package: task-wb-base-system
 Architecture: all


### PR DESCRIPTION
* hubpower актуален для [<wb6](https://wirenboard.com/wiki/%D0%9F%D0%B8%D1%82%D0%B0%D0%BD%D0%B8%D0%B5_USB-%D0%BF%D0%BE%D1%80%D1%82%D0%BE%D0%B2)
* cmux [экспериментальный](https://wirenboard.com/wiki/CMUX), при необходимости можно поставить вручную
* удаление python-wb-io позволяет избавиться от python2 (-15MB)