### PR TITLE
add wb-cloud-agent to wb-suite

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-metapackages (1.18.6) stable; urgency=medium
+
+  * Add wb-cloud-agent to wb-suite
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 25 Apr 2024 19:37:30 +0300
+
 wb-metapackages (1.18.5) stable; urgency=medium
 
   * Add linux-image-wb8/u-boot-wb8 deps

--- a/debian/control
+++ b/debian/control
@@ -44,7 +44,8 @@ Depends: ${misc:Depends}, wb-essential,
          wb-mcu-fw-flasher, wb-mcu-fw-updater,
          wb-device-manager,
          wb-mqtt-confed, wb-mqtt-opcua, wb-mqtt-logs, wb-diag-collect, wb-mqtt-metrics,
-         wb-mqtt-iec104
+         wb-mqtt-iec104,
+         wb-cloud-agent
 
 Package: python3-wb-test-suite-deps
 Architecture: all


### PR DESCRIPTION
Запрет прошивки контроллера из облака fit-ом без предустановленного wb-cloud-agent

связанных PR-ов - куча => проще всего потыкать:
обновиться из тестинг-сета http://deb.wirenboard.com/all@experimental.update-from-cloud:main

ребут
подключить к облаку
обновиться из облака stable-ом; увидеть ругательства
обновиться fit-ом [с поддержкой обновления из облака](https://jenkins.wirenboard.com/job/pipelines/job/build-image/6241/); не увидеть ругательства


wb-cloud-agent будет предустановлен; изменения (чтобы прошивочка собиралась) - тоже выехали в каком-то соседнем pr