### PR TITLE
feat: add wb-scenarios to depends wb-suite package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-metapackages (1.19.1) stable; urgency=medium
+
+  * Add wb-scenarios to wb-suite deps
+
+ -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Thu, 14 Nov 2024 13:25:00 +0300
+
 wb-metapackages (1.19.0) stable; urgency=medium
 
   * Add task-wirenboard-wb8

--- a/debian/control
+++ b/debian/control
@@ -45,7 +45,8 @@ Depends: ${misc:Depends}, wb-essential,
          wb-device-manager,
          wb-mqtt-confed, wb-mqtt-opcua, wb-mqtt-logs, wb-diag-collect, wb-mqtt-metrics,
          wb-mqtt-iec104,
-         wb-cloud-agent
+         wb-cloud-agent,
+         wb-scenarios
 
 Package: python3-wb-test-suite-deps
 Architecture: all


### PR DESCRIPTION
Добавлен пакет сценариев wb-scenarios в дефолтную установку в тестинге
Метод добавления был заранее согласован с Николаем @sikmir

Страницы вики тоже параллельно создаются, первый вариант уже существует тут
https://wirenboard.com/wiki/Scenarios
Там же есть описание реализованного конкретного сценария
https://wirenboard.com/wiki/Scenarios:Devices-control