### PR TITLE
Remove old test-suite metapackages

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-metapackages (1.19.3) stable; urgency=medium
 
-  * wb-suite: add explicit dependency of wb-test-suite-ng on python3-serial 
+  * wb-suite: add explicit dependency of wb-test-suite-ng on python3-serial
+  * remove old test-suite metapackages
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 29 Apr 2025 11:22:54 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-metapackages (1.19.3) stable; urgency=medium
+
+  * wb-suite: add explicit dependency of wb-test-suite-ng on python3-serial 
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 29 Apr 2025 11:22:54 +0300
+
 wb-metapackages (1.19.2) stable; urgency=medium
 
   * wb-suite: add mmc-utils to recommends

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Package: wb-suite
 Architecture: all
 Description: Wirenboard vendor software set
  This metapackage pulls in all the packages from Wirenboard vendor
-Recommends: wb-update-notifier, mc, gpiod, modbus-utils-rpc, serial-tool, mmc-utils
+Recommends: wb-update-notifier, mc, gpiod, modbus-utils-rpc, serial-tool, mmc-utils, python3-serial
 Breaks: wb-test-suite-deps (<= 1.12.0)
 Depends: ${misc:Depends}, wb-essential,
 # configuration
@@ -55,7 +55,7 @@ Breaks: wb-test-suite-deps (<= 1.12.0)
 Replaces: wb-test-suite-deps (<= 1.12.0)
 Description: Wiren Board test-suite dependencies (python3 packages)
  This metapackage pulls in all the packages required for Wiren Board
- post-production tests (python3)
+ post-production tests (python3). Not used for now.
 Depends: ${misc:Depends}, device-tree-compiler, python3-mysqldb, python3-termcolor, python3-serial,
     python3-can, python3-smbus, python3-six, wb-hwconf-manager (>= 1.25), wb-utils (>= 1.65),
     wb-mqtt-adc (>= 2.0.7)

--- a/debian/control
+++ b/debian/control
@@ -48,27 +48,6 @@ Depends: ${misc:Depends}, wb-essential,
          wb-cloud-agent,
          wb-scenarios
 
-Package: python3-wb-test-suite-deps
-Architecture: all
-Provides: wb-test-suite-deps
-Breaks: wb-test-suite-deps (<= 1.12.0)
-Replaces: wb-test-suite-deps (<= 1.12.0)
-Description: Wiren Board test-suite dependencies (python3 packages)
- This metapackage pulls in all the packages required for Wiren Board
- post-production tests (python3). Not used for now.
-Depends: ${misc:Depends}, device-tree-compiler, python3-mysqldb, python3-termcolor, python3-serial,
-    python3-can, python3-smbus, python3-six, wb-hwconf-manager (>= 1.25), wb-utils (>= 1.65),
-    wb-mqtt-adc (>= 2.0.7)
-
-Package: wb-test-suite-dummy
-Architecture: all
-Provides: wb-test-suite (= 0.1.0)
-Description: Dummy package to provide wb-test-suite required by old build scripts
- This is a dummy package which purpose is only to make old build scripts
- not to fail because of missing wb-test-suite (which was removed from public
- repository recently).
- This package can safely be removed or replaced with the actual wb-test-suite.
-
 Package: task-wb-common-pkgs
 Architecture: all
 Description: Wiren Board common packages


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В tsng на тестируемый контроллер закидывается [скрипт](https://github.com/wirenboard/test-suite-ng/blob/main/modules/remote/serial_ports_echo.py), который проверяет RS485 и требует для этого python3-serial. [Ранее](https://github.com/wirenboard/wb-metapackages/pull/26) мы убрали зависимость python3-wb-test-suite-deps который ставил python3-serial и с тех пор это все работает неявно (другой наш софт хочет этот пакет и поэтому он устанавливается). Явное лучше неявного, предлагаю дописать.
Убрали метапакеты от старого тест сьюта, больше не используются
___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


