### PR TITLE
Remove wb-homa-* pkgs from wb-suite deps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-metapackages (1.19.7) stable; urgency=medium
+
+  * wb-suite: remove wb-homa-* packages alternatives
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Mon, 05 May 2025 18:39:02 +0300
+
 wb-metapackages (1.19.6) stable; urgency=medium
 
   * task-wb-common-pkgs: add ethtool, htop,ncdu,fdisk

--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,7 @@ Depends: ${misc:Depends}, wb-essential,
 # utilities
          wb-update-manager, wb-nm-helper,
 # software packages
-         wb-mqtt-w1 | wb-homa-w1, wb-mqtt-gpio | wb-homa-gpio, wb-mqtt-adc | wb-homa-adc,
+         wb-mqtt-w1, wb-mqtt-gpio, wb-mqtt-adc,
          wb-mqtt-serial, wb-mqtt-dac,
          wb-rules, wb-rules-system, wb-mqtt-db, wb-mqtt-db-cli,
          wb-mqtt-mbgate, wb-mqtt-homeui, wb-mqtt-knx,


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Можно убирать homa пакеты из альтернатив зависимостей, их больше нет
https://github.com/wirenboard/wb-mqtt-w1/commit/d0a7a09138a91da9d04291e8ed0691d5fd584dc8
https://github.com/wirenboard/wb-releases/pull/896
___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


