### PR TITLE
Feature/int 464 add autoinstall alice

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -31,13 +31,13 @@ wb-metapackages (1.19.6) stable; urgency=medium
 
 wb-metapackages (1.19.5) stable; urgency=medium
 
-  * Get back  for testing
+  * Get back wb-scenarios for testing
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 29 Apr 2025 13:01:06 +0300
 
 wb-metapackages (1.19.4) stable; urgency=medium
 
-  * Remove  for stable release
+  * Remove wb-scenarios for stable release
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 29 Apr 2025 12:45:33 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-metapackages (1.20.1) stable; urgency=medium
 
-  * Add wb-mqtt-alice to wb-suite deps
+  * Add wb-mqtt-alice to wb-suite recommends
 
  -- Mikhail Burchu <mikhail.burchu@wirenboard.com>  Tue, 05 Aug 2025 12:00:00 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-metapackages (1.20.1) stable; urgency=medium
+
+  * Add wb-mqtt-alice to wb-suite deps
+
+ -- Mikhail Burchu <mikhail.burchu@wirenboard.com>  Tue, 05 Aug 2025 12:00:00 +0300
+
 wb-metapackages (1.20.0) stable; urgency=medium
 
   * Add metapackage for HDMI support
@@ -25,13 +31,13 @@ wb-metapackages (1.19.6) stable; urgency=medium
 
 wb-metapackages (1.19.5) stable; urgency=medium
 
-  * Get back wb-scenarios for testing
+  * Get back  for testing
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 29 Apr 2025 13:01:06 +0300
 
 wb-metapackages (1.19.4) stable; urgency=medium
 
-  * Remove wb-scenarios for stable release
+  * Remove  for stable release
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 29 Apr 2025 12:45:33 +0300
 

--- a/debian/control
+++ b/debian/control
@@ -47,6 +47,7 @@ Depends: ${misc:Depends}, wb-essential,
          wb-mqtt-iec104,
          wb-cloud-agent,
          wb-scenarios
+         wb-mqtt-alice
 
 Package: task-wb-common-pkgs
 Architecture: all

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Package: wb-suite
 Architecture: all
 Description: Wirenboard vendor software set
  This metapackage pulls in all the packages from Wirenboard vendor
-Recommends: wb-update-notifier, mc, gpiod, modbus-utils-rpc, serial-tool, mmc-utils, python3-serial, wb-modbus-ext-scanner
+Recommends: wb-update-notifier, mc, gpiod, modbus-utils-rpc, serial-tool, mmc-utils, python3-serial, wb-modbus-ext-scanner, wb-mqtt-alice
 Breaks: wb-test-suite-deps (<= 1.12.0)
 Depends: ${misc:Depends}, wb-essential,
 # configuration
@@ -46,8 +46,7 @@ Depends: ${misc:Depends}, wb-essential,
          wb-mqtt-confed, wb-mqtt-opcua, wb-mqtt-logs, wb-diag-collect, wb-mqtt-metrics,
          wb-mqtt-iec104,
          wb-cloud-agent,
-         wb-scenarios,
-         wb-mqtt-alice
+         wb-scenarios
 
 Package: task-wb-common-pkgs
 Architecture: all

--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,7 @@ Depends: ${misc:Depends}, wb-essential,
          wb-mqtt-confed, wb-mqtt-opcua, wb-mqtt-logs, wb-diag-collect, wb-mqtt-metrics,
          wb-mqtt-iec104,
          wb-cloud-agent,
-         wb-scenarios
+         wb-scenarios,
          wb-mqtt-alice
 
 Package: task-wb-common-pkgs


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавляем в автоустановку пакета клиента Алисы (wb-mqtt-alice) на контроллере.

___________________________________
**Что поменялось для пользователей:**
Будет "из коробки" интеграция с Алисой. Останется привязать контроллер и настроить конфигурацию устройств.


___________________________________
**Как проверял/а:**
На своем контроллере через тестинг-сет.

