### PR TITLE
Features/hdmi 4 k

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-metapackages (1.20.3) stable; urgency=medium
+
+  * HDMI: Add application dependencies for generating screen refresh rate and applying settings
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Fri, 05 Sep 2025 10:36:31 +0300
+
 wb-metapackages (1.20.2) stable; urgency=medium
 
   * Move wb-cloud-agent to wb-suite recommends

--- a/debian/control
+++ b/debian/control
@@ -166,4 +166,7 @@ Depends: ${misc:Depends},
          x11-xserver-utils,
          matchbox-window-manager,
          firefox-esr,
-         unclutter
+         unclutter,
+         xserver-xorg-core,
+         x11-xserver-utils,
+         libdrm-tests


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил зависимостей в пакет wb-hdmi: утилиты для получения поддерживамых фреймрейтов подключенного монитора, генерации на их основе modeline и применения настроек

___________________________________
**Что поменялось для пользователей:**
Пользователь сможет указывать конкретную частоту фреймрейта для подключенного монитора

___________________________________
**Как проверял/а:**
На wb85 использованием утилит из добавленных зависимостей

