### PR TITLE
Feauture/hdmi weston

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,18 +1,10 @@
-wb-metapackages (1.20.8) stable; urgency=medium
-
-  * HDMI:
-    - keep wb-hdmi as the legacy Xorg runtime metapackage
-    - add wb-hdmi-wayland for the packaged sway runtime stack
-
- -- Wiren Board team <info@wirenboard.com>  Tue, 10 Mar 2026 12:00:00 +0000
-
 wb-metapackages (1.20.7) stable; urgency=medium
 
   * HDMI:
     - split legacy Xorg runtime into wb-hdmi-xorg
     - make wb-hdmi depend on Weston-based runtime packages
 
- -- Wiren Board team <info@wirenboard.com>  Mon, 02 Mar 2026 00:00:00 +0000
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Mon, 17 Mar 2026 00:00:00 +0000
 
 wb-metapackages (1.20.6) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,8 @@ wb-metapackages (1.20.7) stable; urgency=medium
     - keep wb-hdmi as the legacy Xorg runtime metapackage
     - add wb-hdmi-wayland for the wb-sway-kiosk runtime
     - provide wb-hdmi-runtime from both mutually exclusive runtimes
+    - switch systemd runtime services from HDMI runtime metapackage postinst
+    - build deb packages with gzip compression for bullseye dpkg
 
  -- Anton Tarasov <anton.tarasov@wirenboard.com>  Mon, 17 Mar 2026 00:00:00 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
 wb-metapackages (1.20.8) stable; urgency=medium
 
   * HDMI:
-    - switch wb-hdmi runtime dependencies from Weston to sway
-    - depend on wb-sway-kiosk for the packaged sway runtime stack
+    - keep wb-hdmi as the legacy Xorg runtime metapackage
+    - add wb-hdmi-wayland for the packaged sway runtime stack
 
  -- Wiren Board team <info@wirenboard.com>  Tue, 10 Mar 2026 12:00:00 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-metapackages (1.20.8) stable; urgency=medium
 
   * HDMI:
     - switch wb-hdmi runtime dependencies from Weston to sway
-    - add squeekboard and gdbus runtime dependencies
+    - depend on wb-sway-kiosk for the packaged sway runtime stack
 
  -- Wiren Board team <info@wirenboard.com>  Tue, 10 Mar 2026 12:00:00 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
 wb-metapackages (1.20.7) stable; urgency=medium
 
   * HDMI:
-    - split legacy Xorg runtime into wb-hdmi-xorg
-    - make wb-hdmi depend on Weston-based runtime packages
+    - keep wb-hdmi as the legacy Xorg runtime metapackage
+    - add wb-hdmi-wayland for the wb-sway-kiosk runtime
+    - provide wb-hdmi-runtime from both mutually exclusive runtimes
 
  -- Anton Tarasov <anton.tarasov@wirenboard.com>  Mon, 17 Mar 2026 00:00:00 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-metapackages (1.20.7) stable; urgency=medium
+
+  * HDMI:
+    - split legacy Xorg runtime into wb-hdmi-xorg
+    - make wb-hdmi depend on Weston-based runtime packages
+
+ -- Wiren Board team <info@wirenboard.com>  Mon, 02 Mar 2026 00:00:00 +0000
+
 wb-metapackages (1.20.6) stable; urgency=medium
 
   * Add bash-completion to task-wb-base-system

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-metapackages (1.20.8) stable; urgency=medium
+
+  * HDMI:
+    - switch wb-hdmi runtime dependencies from Weston to sway
+    - add squeekboard and gdbus runtime dependencies
+
+ -- Wiren Board team <info@wirenboard.com>  Tue, 10 Mar 2026 12:00:00 +0000
+
 wb-metapackages (1.20.7) stable; urgency=medium
 
   * HDMI:

--- a/debian/control
+++ b/debian/control
@@ -174,6 +174,8 @@ Depends: ${misc:Depends},
          libdrm-tests,
          edid-decode
 Conflicts: wb-hdmi
+Replaces: wb-hdmi
+Provides: wb-hdmi-runtime
 
 Package: wb-hdmi
 Architecture: all
@@ -181,11 +183,10 @@ Description: Wiren Board 8 HDMI packages (Sway runtime)
 Depends: ${misc:Depends},
          wb-configs,
          wb-hwconf-manager,
-         sway,
-         squeekboard,
-         firefox-esr,
-         libglib2.0-bin,
+         wb-sway-kiosk,
          libdrm-tests,
          edid-decode,
          xcvt
 Conflicts: wb-hdmi-xorg
+Replaces: wb-hdmi-xorg
+Provides: wb-hdmi-runtime

--- a/debian/control
+++ b/debian/control
@@ -185,8 +185,7 @@ Depends: ${misc:Depends},
          wb-hwconf-manager,
          wb-sway-kiosk,
          libdrm-tests,
-         edid-decode,
-         xcvt
+         edid-decode
 Conflicts: wb-hdmi-xorg
 Replaces: wb-hdmi-xorg
 Provides: wb-hdmi-runtime

--- a/debian/control
+++ b/debian/control
@@ -158,7 +158,7 @@ Architecture: all
 Description: Wiren Board 8 specific packages
 Recommends: libc6:armhf
 
-Package: wb-hdmi-xorg
+Package: wb-hdmi
 Architecture: all
 Description: Wiren Board 8 HDMI packages (legacy Xorg runtime)
 Depends: ${misc:Depends},
@@ -173,11 +173,10 @@ Depends: ${misc:Depends},
          xserver-xorg-core,
          libdrm-tests,
          edid-decode
-Conflicts: wb-hdmi
-Replaces: wb-hdmi
+Conflicts: wb-hdmi-wayland
 Provides: wb-hdmi-runtime
 
-Package: wb-hdmi
+Package: wb-hdmi-wayland
 Architecture: all
 Description: Wiren Board 8 HDMI packages (Sway runtime)
 Depends: ${misc:Depends},
@@ -186,6 +185,6 @@ Depends: ${misc:Depends},
          wb-sway-kiosk,
          libdrm-tests,
          edid-decode
-Conflicts: wb-hdmi-xorg
-Replaces: wb-hdmi-xorg
+Conflicts: wb-hdmi
+Replaces: wb-hdmi
 Provides: wb-hdmi-runtime

--- a/debian/control
+++ b/debian/control
@@ -177,13 +177,14 @@ Conflicts: wb-hdmi
 
 Package: wb-hdmi
 Architecture: all
-Description: Wiren Board 8 HDMI packages (Weston runtime)
+Description: Wiren Board 8 HDMI packages (Sway runtime)
 Depends: ${misc:Depends},
          wb-configs,
          wb-hwconf-manager,
-         weston,
-         xwayland,
+         sway,
+         squeekboard,
          firefox-esr,
+         libglib2.0-bin,
          libdrm-tests,
          edid-decode,
          xcvt

--- a/debian/control
+++ b/debian/control
@@ -162,6 +162,7 @@ Package: wb-hdmi
 Architecture: all
 Description: Wiren Board 8 HDMI packages (legacy Xorg runtime)
 Depends: ${misc:Depends},
+         alsa-utils,
          wb-configs,
          wb-hwconf-manager,
          xserver-xorg,

--- a/debian/control
+++ b/debian/control
@@ -158,10 +158,12 @@ Architecture: all
 Description: Wiren Board 8 specific packages
 Recommends: libc6:armhf
 
-Package: wb-hdmi
+Package: wb-hdmi-xorg
 Architecture: all
-Description: Wiren Board 8 HDMI packages
+Description: Wiren Board 8 HDMI packages (legacy Xorg runtime)
 Depends: ${misc:Depends},
+         wb-configs,
+         wb-hwconf-manager,
          xserver-xorg,
          xinit,
          x11-xserver-utils,
@@ -169,6 +171,20 @@ Depends: ${misc:Depends},
          firefox-esr,
          unclutter,
          xserver-xorg-core,
-         x11-xserver-utils,
          libdrm-tests,
          edid-decode
+Conflicts: wb-hdmi
+
+Package: wb-hdmi
+Architecture: all
+Description: Wiren Board 8 HDMI packages (Weston runtime)
+Depends: ${misc:Depends},
+         wb-configs,
+         wb-hwconf-manager,
+         weston,
+         xwayland,
+         firefox-esr,
+         libdrm-tests,
+         edid-decode,
+         xcvt
+Conflicts: wb-hdmi-xorg

--- a/debian/rules
+++ b/debian/rules
@@ -7,3 +7,6 @@
 
 %:
 	dh $@
+
+override_dh_builddeb:
+	dh_builddeb -- -Zgzip

--- a/debian/wb-hdmi-wayland.postinst
+++ b/debian/wb-hdmi-wayland.postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "configure" ] && command -v systemctl >/dev/null && [ -d /run/systemd/system ]; then
+	systemctl daemon-reload || true
+	systemctl stop xinit.service || true
+	systemctl disable xinit.service || true
+	systemctl reset-failed xinit.service || true
+	systemctl enable wb-sway-kiosk.service || true
+	systemctl restart wb-sway-kiosk.service || true
+fi
+
+#DEBHELPER#

--- a/debian/wb-hdmi.postinst
+++ b/debian/wb-hdmi.postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "configure" ] && command -v systemctl >/dev/null && [ -d /run/systemd/system ]; then
+	systemctl daemon-reload || true
+	systemctl stop wb-sway-kiosk.service || true
+	systemctl disable wb-sway-kiosk.service || true
+	systemctl reset-failed wb-sway-kiosk.service || true
+	systemctl enable xinit.service || true
+	systemctl restart xinit.service || true
+fi
+
+#DEBHELPER#


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
HDMI-метапакеты разделяются на два явных сценария: wb-hdmi остаётся пакетом для Xorg runtime, а новый wb-hdmi-wayland отвечает за Sway/Wayland runtime. Это нужно, чтобы сохранить совместимость со старыми системами (чтобы не сломать ничего при обновлении) и при этом дать возможность для нового графического стека.

___________________________________
**Что поменялось для пользователей:**
wb-hdmi означает старый Xorg-based HDMI runtime. Для нового стека добавлен wb-hdmi-wayland, который устанавливает wb-sway-kiosk и связанные зависимости. Убраны лишние зависимости, которые больше не нужны в новой схеме, например xcvt.


___________________________________
**Как проверял/а:**
Проверял состав зависимостей и конфликтов в debian/control, синхронизировал его с логикой wb-hwconf-manager, а также проверял поведение новой схемы на тестовых контроллерах с Xorg- и Wayland-стеком.

