### PR TITLE
hdmi: require compatible wb-sway-kiosk

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-metapackages (1.20.9) stable; urgency=medium
+
+  * HDMI: require wb-sway-kiosk with wb-sway-kiosk.service for Wayland runtime.
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Tue, 05 May 2026 09:00:00 +0300
+
 wb-metapackages (1.20.8) stable; urgency=medium
 
   * Move vim to wb-base-system recommends

--- a/debian/control
+++ b/debian/control
@@ -183,7 +183,7 @@ Description: Wiren Board 8 HDMI packages (Sway runtime)
 Depends: ${misc:Depends},
          wb-configs,
          wb-hwconf-manager,
-         wb-sway-kiosk,
+         wb-sway-kiosk (>= 1.5+wb100),
          libdrm-tests,
          edid-decode
 Conflicts: wb-hdmi


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Зафиксировал минимальную версию wb-sway-kiosk в зависимостях wb-hdmi-wayland, чтобы при обновлении wb-hdmi-wayland также бы автоматом обновился wb-sway-kiosk если был установлен ранее. (сейчас он не обновляется)

___________________________________
**Что поменялось для пользователей:**
корректное обновление пакета

___________________________________
**Как проверял/а:**
локальной установкой

